### PR TITLE
Updated Shrink Tower Death Animation

### DIFF
--- a/Assets/Materials.meta
+++ b/Assets/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25a250d661eae0241bc0d1b2b02621d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/_Towers/ShrinkUpgraded/Extended_ShrinkRay.asset
+++ b/Assets/Resources/_Towers/ShrinkUpgraded/Extended_ShrinkRay.asset
@@ -24,9 +24,9 @@ MonoBehaviour:
       type: 3}
     damage: 0.125
     speed: 60
-    maxHit: 1
-    deathEffect: 2
-    BulletDiesOnTargetDeath: 0
+    activateAOE: 0
+    hitAreaRadius: 1
+    deathEffect: 0
   fireRate: 0.01
   attackRadius: 60
   burstDelay: 0

--- a/Assets/Resources/_Towers/ShrinkUpgraded/Overclocked_ShrinkRay.asset
+++ b/Assets/Resources/_Towers/ShrinkUpgraded/Overclocked_ShrinkRay.asset
@@ -23,9 +23,9 @@ MonoBehaviour:
     prefab: {fileID: 437429838871245508, guid: 1ada7056957c2014983f089b49147a0c, type: 3}
     damage: 0.175
     speed: 60
-    maxHit: 1
-    deathEffect: 2
-    BulletDiesOnTargetDeath: 0
+    activateAOE: 0
+    hitAreaRadius: 1
+    deathEffect: 0
   fireRate: 0.01
   attackRadius: 30
   burstDelay: 0

--- a/Assets/Resources/_Towers/_DefaultTowers/Shrink Tower.asset
+++ b/Assets/Resources/_Towers/_DefaultTowers/Shrink Tower.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
     speed: 60
     activateAOE: 0
     hitAreaRadius: 1
-    deathEffect: 2
+    deathEffect: 0
   fireRate: 0.01
   attackRadius: 30
   burstDelay: 0


### PR DESCRIPTION
Set death effect for shrink ray to none again. Doesn't play shrink animation anymore but it at least doesn't play the fly away animation. Either set shrink animation back to none, or make a separate enum option for shrink animation. https://app.clickup.com/t/86962hx1r