### PR TITLE
Fixed freeze prefab for upgrade and Disabled double collision on enemies

### DIFF
--- a/Assets/Prefabs/Characters/AntKnight 1.prefab
+++ b/Assets/Prefabs/Characters/AntKnight 1.prefab
@@ -240,7 +240,7 @@ CapsuleCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 0.5
   m_Height: 4

--- a/Assets/Prefabs/Characters/AntSoldier1.prefab
+++ b/Assets/Prefabs/Characters/AntSoldier1.prefab
@@ -220,7 +220,7 @@ CapsuleCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 0.5
   m_Height: 4

--- a/Assets/Prefabs/Characters/AntSoldierFly.prefab
+++ b/Assets/Prefabs/Characters/AntSoldierFly.prefab
@@ -225,7 +225,7 @@ CapsuleCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 0.5
   m_Height: 2

--- a/Assets/Prefabs/Characters/ShrimpBoss.prefab
+++ b/Assets/Prefabs/Characters/ShrimpBoss.prefab
@@ -205,7 +205,7 @@ CapsuleCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 0.5
   m_Height: 4

--- a/Assets/Prefabs/Characters/ShrimpKnight.prefab
+++ b/Assets/Prefabs/Characters/ShrimpKnight.prefab
@@ -205,7 +205,7 @@ CapsuleCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 0.5
   m_Height: 4

--- a/Assets/Prefabs/Characters/ShrimpSoldier Fast.prefab
+++ b/Assets/Prefabs/Characters/ShrimpSoldier Fast.prefab
@@ -205,7 +205,7 @@ CapsuleCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 0.5
   m_Height: 4

--- a/Assets/Prefabs/Characters/ShrimpSoldier.prefab
+++ b/Assets/Prefabs/Characters/ShrimpSoldier.prefab
@@ -205,7 +205,7 @@ CapsuleCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 0.5
   m_Height: 4

--- a/Assets/Prefabs/Characters/ant empress.prefab
+++ b/Assets/Prefabs/Characters/ant empress.prefab
@@ -225,7 +225,7 @@ CapsuleCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 1
   m_Height: 4.5

--- a/Assets/Prefabs/Characters/ant queen.prefab
+++ b/Assets/Prefabs/Characters/ant queen.prefab
@@ -225,7 +225,7 @@ CapsuleCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 1
   m_Height: 4.5

--- a/Assets/Prefabs/Towers/Freeze_Upgraded/Strong_FreezeRay.prefab
+++ b/Assets/Prefabs/Towers/Freeze_Upgraded/Strong_FreezeRay.prefab
@@ -77,7 +77,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 00211cb2a8f861f41b307d23f22ed697, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  RotateAxis: {fileID: 0}
+  RotateAxis: {fileID: 7962403558800398717}
   BulletSource: {fileID: 7467773047844001000}
 --- !u!135 &3988206964115874246
 SphereCollider:
@@ -178,10 +178,20 @@ PrefabInstance:
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: -4191399356845760233, guid: d83e7a62b03e3b943840ddfede908fc8,
+        type: 3}
+      propertyPath: m_Name
+      value: Top_Shrinkray2
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: d83e7a62b03e3b943840ddfede908fc8,
         type: 3}
       propertyPath: m_Name
       value: FreezerayUG2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8863925792487902272, guid: d83e7a62b03e3b943840ddfede908fc8,
+        type: 3}
+      propertyPath: m_Name
+      value: Bottom_Freezeray
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -205,6 +215,12 @@ Transform:
 --- !u!4 &3233499703380254593 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d83e7a62b03e3b943840ddfede908fc8,
+    type: 3}
+  m_PrefabInstance: {fileID: 3122414716995172458}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7962403558800398717 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -4191399356845760233, guid: d83e7a62b03e3b943840ddfede908fc8,
     type: 3}
   m_PrefabInstance: {fileID: 3122414716995172458}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
Also modified name of Top piece in freeze ray upgrades to be consistent. Currently it calls it shrink ray. Name doesn't affect it.
https://app.clickup.com/t/86963jeja

Two collision was causing double damage overlap on occasion. In case they are necessary for something they have only been disabled and not deleted.
https://app.clickup.com/t/8695nkhvj